### PR TITLE
Convert INTERVAL types to datetime.timedelta values and vice versa.

### DIFF
--- a/IfxPy/ifxpyc.h
+++ b/IfxPy/ifxpyc.h
@@ -105,6 +105,7 @@
 #define PYTHON_DATE      10
 #define PYTHON_TIME      11
 #define PYTHON_TIMESTAMP 12
+#define PYTHON_TIMEDELTA 13
 
 
 


### PR DESCRIPTION
The following INTERVAL types are automatically converted between
the native Informix data type and the datetime.timedelta type of
the Python standsard library:

  DAY
  HOUR
  MINUTE
  SECOND
  DAY TO HOUR
  DAY TO MINUTE
  DAY TO SECOND
  HOUR TO MINUTE
  HOUR TO SECOND
  MINUTE TO SECOND

Support for the following INTERVAL types is missing:

  YEAR
  MONTH
  YEAR TO MONTH

These three types do not fit exactly the datetime.timedelta type
of the Python standard library.